### PR TITLE
refactor(other): move validate pr title help text to the bottom

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,18 +1,5 @@
 <!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->
 
-<!--
-Validate your PR title - a quick Guide
-
-A valid PR title contains a type (https://github.com/commitizen/conventional-commit-types/blob/master/index.json), a scope (https://github.com/ulfgebhardt/issue-templates/blob/master/.github/workflows/test.lint.pr.yml#L31) and a title starting with a lower case letter.
-
-Here are some valid examples:
-- fix(docu): my fix
-- feat(docker): my feature
-- docs(release): my docs
-- refactor(workflow) : my refactor
-- test(other): my test
--->
-
 ## 🍰 Pullrequest
 <!-- Describe the Pullrequest. Use Screenshots if possible. -->
 
@@ -26,3 +13,16 @@ Here are some valid examples:
 ### Todo
 <!-- In case some parts are still missing, list them here. -->
 - [X] None
+
+<!--
+Validate your PR title - a quick Guide
+
+A valid PR title contains a type (https://github.com/commitizen/conventional-commit-types/blob/master/index.json), a scope (https://github.com/ulfgebhardt/issue-templates/blob/master/.github/workflows/test.lint.pr.yml#L31) and a title starting with a lower case letter.
+
+Here are some valid examples:
+- fix(docu): my fix
+- feat(docker): my feature
+- docs(release): my docs
+- refactor(workflow) : my refactor
+- test(other): my test
+-->


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

<!--
Validate your PR title - a quick Guide

A valid PR title contains a type (https://github.com/commitizen/conventional-commit-types/blob/master/index.json), a scope (https://github.com/ulfgebhardt/issue-templates/blob/master/.github/workflows/test.lint.pr.yml#L31) and a title starting with a lower case letter.

Here are some valid examples:
- fix(docu): my fix
- feat(docker): my feature
- docs(release): my docs
- refactor(workflow) : my refactor
- test(other): my test
-->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

move validate pr title help text to the bottom

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
